### PR TITLE
Docker compose multiple containers

### DIFF
--- a/visits/Dockerfile
+++ b/visits/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:alpine
+
+WORKDIR '/app'
+
+COPY package.json .
+RUN npm install
+COPY . .
+
+CMD ["npm", "start"]

--- a/visits/docker-compose.yml
+++ b/visits/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   redis-server:
     image: 'redis'  # base image of redis - this is equivalent to running 'docker run redis' which would pull the base image from docker hub and start redis server
   node-app:
+    restart: on-failure
     build: .  # build takes a path to the Dockerfile you're trying to build from
     ports:
       - "4001:8081"   # A - in .yml files indicates an array

--- a/visits/docker-compose.yml
+++ b/visits/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'  # specifies version of docker compose
+services:
+  redis-server:
+    image: 'redis'  # base image of redis - this is equivalent to running 'docker run redis' which would pull the base image from docker hub and start redis server
+  node-app:
+    build: .  # build takes a path to the Dockerfile you're trying to build from
+    ports:
+      - "4001:8081"   # A - in .yml files indicates an array

--- a/visits/index.js
+++ b/visits/index.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const redis = require('redis');
+
+const app = express();
+
+const client = redis.createClient();
+client.set('visits', 0);
+
+const CONTAINER_PORT = 8081;
+
+app.get('/', (req, res) => {
+  client.get('visits', (err, visits) => {
+    res.send(`Number of visits is ${visits}`);
+    client.set('visits', parseInt(visits, 10) + 1);
+  });
+});
+
+app.listen(CONTAINER_PORT, () => {
+  console.log(`Listening on port ${CONTAINER_PORT}`);
+});

--- a/visits/index.js
+++ b/visits/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const redis = require('redis');
+const process = require('process');
 
 const app = express();
 
@@ -13,6 +14,7 @@ const CONTAINER_PORT = 8081;
 
 app.get('/', (req, res) => {
   client.get('visits', (err, visits) => {
+    if (err) { process.exit(1); }
     res.send(`Number of visits is ${visits}`);
     client.set('visits', parseInt(visits, 10) + 1);
   });

--- a/visits/index.js
+++ b/visits/index.js
@@ -3,7 +3,10 @@ const redis = require('redis');
 
 const app = express();
 
-const client = redis.createClient();
+const client = redis.createClient({
+  host: 'redis-server',  // You can reference the redis server by its name in the docker-compose.yml file
+  port: 6379
+});
 client.set('visits', 0);
 
 const CONTAINER_PORT = 8081;

--- a/visits/package.json
+++ b/visits/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "express": "*",
+    "redis": "2.8.0"
+  },
+  "scripts": {
+    "start": "node index.js"
+  }
+}


### PR DESCRIPTION
Small example app that spins up a redis server and node-app server in a small network using docker-compose.yml. Added port mapping, restart policies, etc. The node server increments a count, number of visits, each time / is visited, and exits with a nonzero exit code when redis errors are encountered while updating the store. The restart policy is on-failure